### PR TITLE
fix: don't ignore non-hsl colors, skip id key of theme

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -97,6 +97,7 @@ const getCompletionItems = (params) => {
 
         Object.entries(themes).forEach(([themeName, theme]) => {
           Object.entries(theme).forEach(([colorKey, val]) => {
+            if (colorKey === 'id') return
             if (!colorsFromOtherThemes[colorKey]) {
               colorsFromOtherThemes[colorKey] = {}
             }
@@ -118,6 +119,7 @@ const getCompletionItems = (params) => {
         console.log("[colors-from]", colorsFromOtherThemes)
 
         Object.entries(firstTheme).forEach(([key, theme]) => {
+          if (key === 'id') return
           const name = `$${key}`
 
           const allColors = Object.entries(colorsFromOtherThemes[key])


### PR DESCRIPTION
## Background

This PR fixes two bugs:

* ~~Theme values that don't use `hsl/hsla()` are currently ignored. Hex, `rgb/rgba()`, or named colors get skipped.~~
* The `id` field of each theme was being recorded as a theme value. This field contains the name of the theme.

## Changes

* ~~Remove the condition checking for `hsl/hsla()` values when generating theme markdown~~
* Skip over the `id` key of the theme object